### PR TITLE
feat: add knowledge hooks for automatic capture and whisper loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,61 @@ User: "How do we handle authentication in this project?"
 Claude: Uses knowledge-retriever to search for established auth patterns
 ```
 
+## Hooks (Automatic Knowledge Loop)
+
+In addition to agents, this plugin includes hooks for automatic knowledge injection and capture.
+
+### Installation
+
+```bash
+# After installing the plugin, set up hooks:
+./hooks/install.sh
+```
+
+### What the Hooks Do
+
+| Hook | Event | Purpose |
+|------|-------|---------|
+| `inject-knowledge.sh` | SessionStart | Injects profile, project context, blockers at session start |
+| `knowledge-capture.sh` | UserPromptSubmit | Captures milestones/decisions/blockers + semantic whispers |
+
+### The Knowledge Whisper Loop
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    THE WHISPER LOOP                         │
+├─────────────────────────────────────────────────────────────┤
+│  You type → [UserPromptSubmit hook]                         │
+│                    ↓                                        │
+│            ┌──────────────────┐                             │
+│            │ CAPTURE          │                             │
+│            │ • milestones     │ → know add                  │
+│            │ • decisions      │                             │
+│            │ • blockers       │                             │
+│            └──────────────────┘                             │
+│                    ↓                                        │
+│            ┌──────────────────┐                             │
+│            │ WHISPER          │                             │
+│            │ • semantic search│ → know search --semantic    │
+│            │ • inject context │ → <knowledge-whisper>       │
+│            └──────────────────┘                             │
+│                    ↓                                        │
+│              Claude responds with full context              │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Configuration
+
+Set these environment variables for full functionality:
+
+```bash
+# Profile ID for session briefing (find with: know entries | grep -i profile)
+export KNOW_PROFILE_ID="your-profile-entry-id"
+
+# Vision repo for backlog injection
+export KNOW_VISION_REPO="yourorg/vision"
+```
+
 ## How It Works
 
 ```

--- a/hooks/inject-knowledge.sh
+++ b/hooks/inject-knowledge.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Session Start Hook - Injects relevant knowledge context
+# Called by Claude Code on session start
+
+# Find know CLI
+KNOW="${KNOW_CLI:-$(which know 2>/dev/null || echo "$HOME/.config/composer/vendor/bin/know")}"
+
+# Default profile ID (can be overridden via env)
+PROFILE_ID="${KNOW_PROFILE_ID:-}"
+
+# Parse input
+INPUT=$(cat)
+CWD=$(echo "$INPUT" | jq -r '.cwd // ""' 2>/dev/null)
+
+if [ -z "$CWD" ]; then
+    exit 0
+fi
+
+# Get repo name from git or directory
+REPO=$(cd "$CWD" 2>/dev/null && basename "$(git remote get-url origin 2>/dev/null)" .git 2>/dev/null || basename "$CWD")
+
+# Build context
+CONTEXT=""
+
+# Inject profile if configured (strip ANSI codes and table formatting)
+if [ -n "$PROFILE_ID" ] && [ -x "$KNOW" ]; then
+    PROFILE=$($KNOW show "$PROFILE_ID" 2>/dev/null | sed 's/\x1b\[[0-9;]*[a-zA-Z]//g' | sed 's/\x1b\[?[0-9]*[a-zA-Z]//g' | grep -v "^[[:space:]]*[┌├└│─┬┴┼┐┤┘⠂]" | grep -v "Fetching" | grep -v "^ID:" | grep -v "^$" | head -20)
+    if [ -n "$PROFILE" ]; then
+        CONTEXT+="## Who You're Talking To"$'\n'"$PROFILE"$'\n\n'
+    fi
+fi
+
+# Get open issues from vision repo if configured
+VISION_REPO="${KNOW_VISION_REPO:-}"
+if [ -n "$VISION_REPO" ]; then
+    ISSUES=$(gh issue list --repo "$VISION_REPO" --limit=5 --state=open 2>/dev/null | awk -F'\t' '{print "- #"$1": "$3}')
+    if [ -n "$ISSUES" ]; then
+        CONTEXT+="## Vision Backlog (Open Issues)"$'\n'"$ISSUES"$'\n\n'
+    fi
+fi
+
+# Get repo-specific entries via semantic search
+if [ -x "$KNOW" ]; then
+    REPO_ENTRIES=$($KNOW search --semantic "$REPO" --limit=3 2>/dev/null | grep -E "^\[" | head -3)
+    if [ -n "$REPO_ENTRIES" ]; then
+        CONTEXT+="## Project: $REPO"$'\n'"$REPO_ENTRIES"$'\n\n'
+    fi
+
+    # Get active blockers
+    BLOCKERS=$($KNOW search --semantic "active blockers stuck waiting" --limit=3 2>/dev/null | grep -E "^\[" | head -3)
+    if [ -n "$BLOCKERS" ]; then
+        CONTEXT+="## Active Blockers"$'\n'"$BLOCKERS"$'\n\n'
+    fi
+fi
+
+# Output context directly - Claude Code will inject this
+if [ -n "$CONTEXT" ]; then
+    echo "<knowledge-context>"
+    echo "$CONTEXT"
+    echo "</knowledge-context>"
+fi
+
+exit 0

--- a/hooks/install.sh
+++ b/hooks/install.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Install know-plugin hooks for Claude Code
+# Sets up automatic knowledge injection and capture
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLAUDE_DIR="$HOME/.claude"
+HOOKS_DIR="$CLAUDE_DIR/hooks"
+SETTINGS_FILE="$CLAUDE_DIR/settings.json"
+
+echo "Installing know-plugin hooks..."
+
+# Create hooks directory if it doesn't exist
+mkdir -p "$HOOKS_DIR"
+
+# Copy hook scripts
+cp "$SCRIPT_DIR/inject-knowledge.sh" "$HOOKS_DIR/"
+cp "$SCRIPT_DIR/knowledge-capture.sh" "$HOOKS_DIR/"
+chmod +x "$HOOKS_DIR/inject-knowledge.sh"
+chmod +x "$HOOKS_DIR/knowledge-capture.sh"
+
+echo "✓ Copied hooks to $HOOKS_DIR"
+
+# Check if settings.json exists
+if [ ! -f "$SETTINGS_FILE" ]; then
+    echo "Creating $SETTINGS_FILE..."
+    echo '{"$schema": "https://json.schemastore.org/claude-code-settings.json", "hooks": {}}' > "$SETTINGS_FILE"
+fi
+
+# Backup existing settings
+cp "$SETTINGS_FILE" "$SETTINGS_FILE.backup"
+
+# Update settings.json with hooks configuration using jq
+HOOKS_CONFIG='{
+  "SessionStart": [{
+    "matcher": "startup",
+    "hooks": [{
+      "type": "command",
+      "command": "bash ~/.claude/hooks/inject-knowledge.sh",
+      "timeout": 15
+    }]
+  }],
+  "UserPromptSubmit": [{
+    "hooks": [{
+      "type": "command",
+      "command": "bash ~/.claude/hooks/knowledge-capture.sh",
+      "timeout": 10
+    }]
+  }]
+}'
+
+# Merge hooks config into settings
+if command -v jq &> /dev/null; then
+    jq --argjson hooks "$HOOKS_CONFIG" '.hooks = ($hooks * .hooks)' "$SETTINGS_FILE" > "$SETTINGS_FILE.tmp" && mv "$SETTINGS_FILE.tmp" "$SETTINGS_FILE"
+    echo "✓ Updated $SETTINGS_FILE with hooks configuration"
+else
+    echo "⚠ jq not found - please manually add hooks to $SETTINGS_FILE"
+    echo "Hooks config:"
+    echo "$HOOKS_CONFIG"
+fi
+
+echo ""
+echo "Installation complete!"
+echo ""
+echo "Optional configuration (add to ~/.bashrc or ~/.zshrc):"
+echo ""
+echo "  # Profile ID for session briefing (find with: know entries | grep -i profile)"
+echo "  export KNOW_PROFILE_ID=\"your-profile-entry-id\""
+echo ""
+echo "  # Vision repo for backlog injection"
+echo "  export KNOW_VISION_REPO=\"yourorg/vision\""
+echo ""
+echo "Restart Claude Code to activate hooks."

--- a/hooks/knowledge-capture.sh
+++ b/hooks/knowledge-capture.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Knowledge Hook: Capture + Whisper
+# 1. Captures milestones, decisions, blockers from user messages
+# 2. Semantic search whispers relevant knowledge on every message
+
+# Find know CLI
+KNOW="${KNOW_CLI:-$(which know 2>/dev/null || echo "$HOME/.config/composer/vendor/bin/know")}"
+LOG="${KNOW_LOG:-$HOME/.claude/hooks/knowledge-capture.log}"
+
+# Skip if know not available
+if [ ! -x "$KNOW" ]; then
+    exit 0
+fi
+
+# Parse input from stdin
+INPUT=$(cat)
+PROMPT=$(echo "$INPUT" | jq -r '.prompt // ""' 2>/dev/null)
+CWD=$(echo "$INPUT" | jq -r '.cwd // ""' 2>/dev/null)
+PROJECT=$(basename "$CWD" 2>/dev/null || echo "unknown")
+
+# Skip empty or very short prompts
+if [ -z "$PROMPT" ] || [ ${#PROMPT} -lt 10 ]; then
+    exit 0
+fi
+
+# Lowercase for matching
+LOWER=$(echo "$PROMPT" | tr "[:upper:]" "[:lower:]")
+
+# ============ CAPTURE PHASE ============
+CAPTURED=""
+
+# Milestone patterns
+if echo "$LOWER" | grep -qE "(tests? pass|all green|coverage|pr merged|deployed|released|feature complete|finished|done with|working now|fixed|resolved)"; then
+    TITLE=$(echo "$PROMPT" | head -c 100)
+    $KNOW add "Milestone: $TITLE" \
+        --category="architecture" \
+        --tags="milestone,auto-captured,$PROJECT,$(date +%Y-%m-%d)" \
+        --priority="high" \
+        --status="validated" \
+        --content="Auto-captured from Claude Code session. Project: $PROJECT" \
+        2>/dev/null || true
+    echo "[$(date)] MILESTONE [$PROJECT]: $PROMPT" >> "$LOG"
+    CAPTURED="milestone"
+fi
+
+# Decision patterns
+if echo "$LOWER" | grep -qE "(lets go with|decided on|choosing|going to use|switching to|instead of|better approach|makes more sense)"; then
+    TITLE=$(echo "$PROMPT" | head -c 100)
+    $KNOW add "Decision: $TITLE" \
+        --category="architecture" \
+        --tags="decision,auto-captured,$PROJECT,$(date +%Y-%m-%d)" \
+        --priority="high" \
+        --content="Auto-captured from Claude Code session. Project: $PROJECT" \
+        2>/dev/null || true
+    echo "[$(date)] DECISION [$PROJECT]: $PROMPT" >> "$LOG"
+    CAPTURED="decision"
+fi
+
+# Blocker patterns
+if echo "$LOWER" | grep -qE "(blocked by|cant proceed|stuck on|waiting for|depends on)"; then
+    TITLE=$(echo "$PROMPT" | head -c 100)
+    $KNOW add "Blocker: $TITLE" \
+        --category="debugging" \
+        --tags="blocker,auto-captured,$PROJECT,$(date +%Y-%m-%d)" \
+        --priority="critical" \
+        --status="draft" \
+        --content="Auto-captured from Claude Code session. Project: $PROJECT" \
+        2>/dev/null || true
+    echo "[$(date)] BLOCKER [$PROJECT]: $PROMPT" >> "$LOG"
+    CAPTURED="blocker"
+fi
+
+# ============ WHISPER PHASE ============
+# Use semantic search on the full prompt for better relevance
+WHISPER=""
+
+# Semantic search with the user's prompt (truncate to 200 chars for query)
+QUERY=$(echo "$PROMPT" | head -c 200)
+RESULTS=$($KNOW search --semantic "$QUERY" --limit=3 2>/dev/null | tail -n +3)
+
+# Process each entry block
+while IFS= read -r line; do
+    # Title line (starts with [)
+    if [[ "$line" =~ ^\[([a-f0-9-]+)\] ]]; then
+        WHISPER+="$line"$'\n'
+    # Content snippet lines (not Category/Tags metadata)
+    elif [[ -n "$line" && ! "$line" =~ ^(Category:|Tags:|Found) ]]; then
+        WHISPER+="  ↳ $line"$'\n'
+    fi
+done <<< "$RESULTS"
+
+# Output whisper if we found anything
+if [ -n "$WHISPER" ]; then
+    WHISPER=$(echo "$WHISPER" | head -15)
+    echo "<knowledge-whisper>"
+    echo "$WHISPER"
+    echo "</knowledge-whisper>"
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Adds Claude Code hooks for automatic knowledge capture and injection:

- **SessionStart hook** (`inject-knowledge.sh`): Injects profile, vision backlog, project context, and blockers at session start
- **UserPromptSubmit hook** (`knowledge-capture.sh`): Auto-captures milestones, decisions, blockers + semantic whisper on every message
- **Install script** (`install.sh`): Configures Claude Code settings.json with hook registration

## The Knowledge Whisper Loop

```
You type → [UserPromptSubmit hook]
                ↓
        ┌──────────────────┐
        │ CAPTURE          │
        │ • milestones     │ → know add
        │ • decisions      │
        │ • blockers       │
        └──────────────────┘
                ↓
        ┌──────────────────┐
        │ WHISPER          │
        │ • semantic search│ → know search --semantic
        │ • inject context │ → <knowledge-whisper>
        └──────────────────┘
                ↓
          Claude responds with full context
```

## Test Plan

- [ ] Run `./hooks/install.sh` on clean Claude Code install
- [ ] Start new session, verify `<knowledge-context>` injection
- [ ] Send messages, verify `<knowledge-whisper>` appears
- [ ] Use trigger phrases ("decided on", "tests passing"), verify capture to know

🤖 Generated with [Claude Code](https://claude.com/claude-code)